### PR TITLE
Fixed conflict with /usr/bin on rpm install

### DIFF
--- a/utils/bbcp.spec
+++ b/utils/bbcp.spec
@@ -48,7 +48,7 @@ rm -rf %{buildroot}
 
 
 %files
-%{instdir}/bin
+%{instdir}/bin/bbcp
 
 # ================= ChangeLog =========================
 


### PR DESCRIPTION
After building RPM and trying to install, the following error is thrown:

```
sudo rpm -ivh bbcp-14.9.2-1.el7.x86_64.rpm 
Preparing...                          ################################# [100%]
	file /usr/bin from install of bbcp-14.9.2-1.el7.x86_64 conflicts with file from package filesystem-3.2-25.el7.x86_64
```

It seemed that the following lines in the build spec are being interpreted to mean that `/usr/bin` is a file to be installed, which is not what we want.

```
%files
%{instdir}/bin
```

Changing this to `%{instdir}/bin/bbcp` results in a successful installation.